### PR TITLE
Interactive preview of Calspec data

### DIFF
--- a/jwst_nb_viz/calspec/calspec_preview.ipynb
+++ b/jwst_nb_viz/calspec/calspec_preview.ipynb
@@ -1,0 +1,566 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "the goal of this notebook is to remotely load and preview spectrophotometric standards for use with JWST spectra\n",
+    "\n",
+    "would like to click a star name and display both an image cutout preview and an interactive spectrum\n",
+    "\n",
+    "Things to Not Like\n",
+    "- no master list of standard stars\n",
+    "- no easy way of getting spectral data of standards in catalog (e.g. calspec)\n",
+    "- replace in network path with public version for spectral standard data grab\n",
+    "- have astroquery make clear what the line catalogs are \n",
+    "- not one service that gives full list of lines (all have different interfaces and different available properties)\n",
+    "- need input from experts to provide contextual info for important and useful strong lines\n",
+    "- have way to overplot lines based on context and groups/sets of lines \n",
+    "- do not like scrolling back and forth\n",
+    "- combine the 3 html calspec tables into a single FITS file readable by Astropy Table or Pandas \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from io import BytesIO\n",
+    "from astropy.io import fits\n",
+    "from astropy.wcs import WCS\n",
+    "import astropy.units as u\n",
+    "import astroquery\n",
+    "from astroquery.skyview import SkyView\n",
+    "import holoviews as hv\n",
+    "hv.extension('bokeh')\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clean_stis(df):\n",
+    "    '''Clean the STIS column in the catalog '''\n",
+    "    stis=[]\n",
+    "    for row in df.itertuples():\n",
+    "        if row.STIS is None or '_stis' not in row.STIS:\n",
+    "            if row.Model is not None and '_stis' in row.Model:\n",
+    "                name = row.Model\n",
+    "            elif '_stis' in row.Name:\n",
+    "                name = row.Name\n",
+    "        else:\n",
+    "            name = row.STIS\n",
+    "        stis.append(name.lower().replace('*', ''))\n",
+    "    df['STIS'] = stis\n",
+    "    \n",
+    "    # fix the SDSS name\n",
+    "    row = df.loc[df['Star_name'].str.contains(\"SDSS\")]\n",
+    "    row.Name = row.B_V\n",
+    "    df.loc[df['Star_name'].str.contains(\"SDSS\")]=row \n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# read in a clipboard/catalog table of standards\n",
+    "file = 'calspec_catalog.csv'\n",
+    "if os.path.exists(file):\n",
+    "    df = pd.read_csv(file, index_col=None)\n",
+    "    df = df.fillna('None')\n",
+    "else:\n",
+    "    # copy from Table 1 at http://www.stsci.edu/hst/observatory/crds/calspec.html\n",
+    "    df=pd.read_clipboard(sep='[\\s]{2,}', header=0)\n",
+    "    df = df.drop(0)\n",
+    "    # format column names \n",
+    "    df.columns = [c.replace(' ', '_').replace('**', '').replace('-', '_') for c in df.columns]\n",
+    "    # fix STIS column\n",
+    "    df = clean_stis(df)\n",
+    "    # make specfile column\n",
+    "    df['specfile']=df['Name']+df['STIS']+'.fits'\n",
+    "    # write to csv \n",
+    "    df.to_csv('calspec_catalog.csv', index=None)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#target = '2MASS J00361617+1821104'\n",
+    "target = '10 Lac'\n",
+    "target_root = df.loc[df['Star_name']==target]['Name'].values.tolist()[0]\n",
+    "surveys = ['DSS2 Red', '2MASS-K']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_image(target, surveys=None, download=False, **kwargs):\n",
+    "    ''' Retrieve image data for a given target '''\n",
+    "    \n",
+    "    if not surveys:\n",
+    "        surveys = ['DSS2 Red', '2MASS-K']\n",
+    "    \n",
+    "    try:\n",
+    "        if download:\n",
+    "            files = SkyView.get_images(position=target,survey=surveys, **kwargs)\n",
+    "        else:\n",
+    "            files = SkyView.get_image_list(position=target,survey=surveys, **kwargs)\n",
+    "    except Exception as e:\n",
+    "        print(f'Error retrieving SkyView preview: {e}')\n",
+    "        return None\n",
+    "\n",
+    "    # produce the hdu\n",
+    "    if download:\n",
+    "        hdus = files\n",
+    "    else:\n",
+    "        hdus = []\n",
+    "        for file in files:\n",
+    "            h = create_hdu(file)\n",
+    "            hdus.append(h)\n",
+    "    return hdus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_hdu(file):\n",
+    "    ''' create HDU from a bytes remote request content '''\n",
+    "    r = requests.get(file)\n",
+    "    hdu = None\n",
+    "    if r.ok:\n",
+    "        img = BytesIO(r.content)\n",
+    "        hdu = fits.HDUList.fromfile(img)\n",
+    "    else:\n",
+    "        raise RuntimeError(f'Error getting request. Status Code: {r.status_code}')\n",
+    "    return hdu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# look up the SkyPreview\n",
+    "hdus = get_image(target, surveys=surveys, radius=1*u.arcmin)\n",
+    "if hdus:\n",
+    "    dss, twomass = hdus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get wcs\n",
+    "wcs_dss = WCS(dss[0].header)\n",
+    "wcs_twomass = WCS(twomass[0].header)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create static preview\n",
+    "ax = plt.subplot(221, projection=wcs_dss)\n",
+    "\n",
+    "ax1 = plt.subplot(1,2,1, projection=wcs_twomass)\n",
+    "ax1.imshow(dss[0].data, origin='lower')\n",
+    "ax1.set_title(f'{surveys[0]}: {target}')\n",
+    "\n",
+    "# raw pixel plot\n",
+    "ax2 = plt.subplot(1,2,2, projection=wcs2)\n",
+    "ax2.imshow(twomass[0].data, origin='lower')\n",
+    "ax2.set_title(f'{surveys[1]}: {target}')\n",
+    "\n",
+    "ax1.figure.set_size_inches((15,15))\n",
+    "ax2.figure.set_size_inches((15,15))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_spectra(df, target=None, caltype=None):\n",
+    "    ''' find relavant spectra from the calspec directory '''\n",
+    "\n",
+    "    if target != '*':\n",
+    "        caltype = df.loc[df['Star name']==target]['STIS**'].values.tolist()[0]\n",
+    "        \n",
+    "    path = '/grp/hst/cdbs/calspec/'\n",
+    "    target = target.replace(' ', '').lower()\n",
+    "    files = glob.glob(path+f'*{target}*{caltype}*.fits')\n",
+    "    return files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_specdf(file):\n",
+    "    ''' Read in a spectro standard star file in produce a Pandas DF '''\n",
+    "    name = file.rsplit('/', 1)[1].split('_')[0]\n",
+    "    h = fits.open(file)\n",
+    "    specdf = Table(h[1].data).to_pandas()\n",
+    "    specdf['STARNAME'] = name.upper() \n",
+    "    return specdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "next goal - make a widget with dropdown menu of standard to select\n",
+    "list of standards"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get a list of files from the clipboard table\n",
+    "# files=[]\n",
+    "# for row in df:\n",
+    "#     files.extend(find_spectra(target=row.Name))\n",
+    "# files\n",
+    "\n",
+    "#\n",
+    "# TODO: generalize this and replace the find_spectra function\n",
+    "#\n",
+    "\n",
+    "# get files from table\n",
+    "path = '/grp/hst/cdbs/calspec/'\n",
+    "#files = [path+'{0}{1}.fits'.format(row.Name,row.STIS.replace('*', '')) for row in df[['Name', 'STIS']].itertuples() if row.STIS != 'None']\n",
+    "#files\n",
+    "files = path + df['specfile']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get a list of spectral calibration spectra filenames\n",
+    "#files = find_spectra(df, target=target)\n",
+    "files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_master(files):\n",
+    "    ''' build a master pandas dataframe from a list of spec files '''\n",
+    "    master=None\n",
+    "    for file in files:\n",
+    "        tmp_df = get_specdf(file)\n",
+    "        #print(tmp_df['STARNAME'])\n",
+    "        if master is not None:\n",
+    "            master = master.append(tmp_df)\n",
+    "        else:\n",
+    "            master = tmp_df\n",
+    "    return master"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# build a master list of files\n",
+    "master = build_master(files)\n",
+    "master.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# build interactive display widget for all stars in master list\n",
+    "master_macro = hv.Dataset(master, ['STARNAME', 'WAVELENGTH'])\n",
+    "master_macro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create water lines overlay and text\n",
+    "lines=[23472.003301137982,\n",
+    " 23326.981220208632,\n",
+    " 23234.492318049546,\n",
+    " 23185.055480707324,\n",
+    " 23114.723654546422,\n",
+    " 23022.387506391973,\n",
+    " 22981.419669019673,\n",
+    " 22905.610364976637,\n",
+    " 22781.239191728437,\n",
+    " 22309.74469086192]\n",
+    "lines = [np.min(lines), np.max(lines)]\n",
+    "#lines=lines[0]\n",
+    "vline = None\n",
+    "for i, line in enumerate(lines):\n",
+    "    wave = line\n",
+    "    text = hv.Text(wave, 2e-14, f\" L{i}\", halign='left')\n",
+    "    if vline:\n",
+    "        vline *= hv.VLine(wave).opts(color='black')*text\n",
+    "    else:\n",
+    "        vline = hv.VLine(wave).opts(color='black')*text\n",
+    "    \n",
+    "# create line curves\n",
+    "curves = master_macro.to(hv.Curve, 'WAVELENGTH', 'FLUX', groupby='STARNAME')\n",
+    "curves.redim(WAVELENGTH=hv.Dimension('WAVELENGTH', soft_range=(5000, 50000))).redim(FLUX=hv.Dimension('FLUX', soft_range=(0,3e-14))).opts(width=600)*vline\n",
+    "#curves.opts(width=600)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dss[0].data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(dss[0].data)\n",
+    "import numpy as np\n",
+    "data = hv.Dataset((np.arange(300), np.arange(300), dss[0].data), ['y', 'x'], 'Flux')\n",
+    "data.to(hv.Image,['x', 'y'])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def hv_image(starname):\n",
+    "    # data = dss[0]\n",
+    "    hdu = get_image(starname, surveys=['DSS2 Red'], radius=1*u.arcmin)[0]\n",
+    "    data = hdu[0].data\n",
+    "    n1, n2 = data.shape\n",
+    "    dataset = hv.Dataset((np.arange(n1), np.arange(n2), data), ['y', 'x'], 'Flux')\n",
+    "    return dataset.to(hv.Image, ['x', 'y'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = hv.DynamicMap(hv_image, kdims=['starname'])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image.redim.range(starname=('10 Lac', 'GD 153'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test(starname):\n",
+    "    hdu = get_image(starname, surveys=['DSS2 Red'], radius=1*u.arcmin)[0]\n",
+    "    return hv.Image(hdu[0].data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "testim = hv.DynamicMap(test, kdims=['starname'])\n",
+    "testim\n",
+    "testim.redim.range(starname=('10 Lac', 'GD 153'))\n",
+    "#clifford.redim.range(a=(-1.5,-1),b=(1.5,2),c=(1,1.2),d=(0.75,0.8), x=(-2,2), y=(-2,2))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "newdf = pd.read_clipboard('[\\s]{2,}')\n",
+    "newdf=newdf.drop(0)\n",
+    "newdf.columns = [c.replace(' ', '_').replace('**', '').replace('-', '_') for c in newdf.columns]\n",
+    "newdf.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files = [path+f for f in df['specfile'].values.tolist()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d=get_image(target, surveys=['DSS2 Red'], radius=1*u.arcmin)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d[0].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['Star_name']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subset = master.loc[master['STARNAME']=='10LAC']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c=hv.Curve(subset, kdims=['WAVELENGTH', 'FLUX']).opts(width=600).redim(WAVELENGTH=hv.Dimension('WAVELENGTH', range=(0, 50000)))\n",
+    "t=hv.Image(dss[0].data)\n",
+    "e=c+t\n",
+    "e"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR includes a notebook to interactively view calibration spectra of standard stars from the CalSpec library, taken from http://www.stsci.edu/hst/observatory/crds/calspec.html.  It is in a halfway done state.  It currently allows the generation of static images for a single target.  It also reads in and displays all the spectral data in an interactive window using Holoviews.  