### PR TITLE
Support firefox if chrome not installed

### DIFF
--- a/jupyter_platform/astrowidgets_viewer_osx
+++ b/jupyter_platform/astrowidgets_viewer_osx
@@ -6,6 +6,10 @@ VOILA_PID=$!
 echo "VOILA: $VOILA_PID"
 sleep 2
 #open http://localhost:8866/
-/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --app=http://localhost:8866
+if [ -d "/Applications/Google\ Chrome.app" ]; then
+    /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --app=http://localhost:8866
+elif [ -d "/Applications/Firefox.app" ]; then
+    open -a Firefox "http://localhost:8866"
+fi
 trap "kill $VOILA_PID; exit 1" INT
 wait


### PR DESCRIPTION
If accessing chrome fails, check for firefox and use that browser instead.