### PR TITLE
Background estimation workflow for imaging

### DIFF
--- a/jdat_notebooks/background_estimation_imaging/Imaging Sky Background Estimation.ipynb
+++ b/jdat_notebooks/background_estimation_imaging/Imaging Sky Background Estimation.ipynb
@@ -1,0 +1,1050 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Draft: Imaging Sky Background Estimation\n",
+    "\n",
+    "This Jupyter notebook provides some tips on estimating the sky background for relatively complex scenes. It also demonstrates ways to evaluate the quality of this sky estimation. \n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "Sky estimation is one of the tricker aspects of image processing. This is in part because the \"sky\" is part of the astronomical scene. Some of what is considered background may be in the foreground (thermal background in the detector, scattered light, or zodiacal light). Sometimes the objects of interest overlap (galaxies in front of other galaxies). This notebook does not address the \"de-blending\" problem of overlapping galaxies, but does outline some of the techniques for dealing with large-scale patterns in the sky. \n",
+    "\n",
+    "The Photutils manual has an extensive discussion of [background estimation](https://photutils.readthedocs.io/en/stable/background.html), which is the basis for much of what is in this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "\n",
+    " * Numpy for general array computations\n",
+    " * Scipy for some stats operations and interpolation\n",
+    " * Photutils for photometry calculations\n",
+    " * Astropy table for viewing the parameters of the sky-background blemishes\n",
+    " * Astropy convolution for smoothing the image \n",
+    " * Routines from photutils for background subtraction and masking\n",
+    " * Astropy tables for manipulating a list of sources (galaxies) injected into the image\n",
+    " * Astropy convolution for dilating the sky image and source mask\n",
+    " * Astropy modeling for fitting a line to the residuals of the background subtraction\n",
+    " * Astropy block_reduce for looking at the RMS of the residuals as a function of scale (blocking factor)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For style checking\n",
+    "# %load_ext pycodestyle_magic\n",
+    "# %flake8_on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from scipy import stats, ndimage, interpolate\n",
+    "from astropy import stats as astrostats\n",
+    "from photutils import (\n",
+    "    datasets,  # For making simulated data\n",
+    "    Background2D,  # For estimating the background\n",
+    "    MedianBackground, BiweightLocationBackground, SExtractorBackground,\n",
+    "    BkgIDWInterpolator, BkgZoomInterpolator,  # For interpolating background\n",
+    "    make_source_mask)\n",
+    "from photutils.utils import ShepardIDWInterpolator as idw\n",
+    "from astropy.table import Table\n",
+    "from astropy.convolution import (\n",
+    "    convolve, Box2DKernel, Tophat2DKernel,\n",
+    "    Ring2DKernel, Gaussian2DKernel)\n",
+    "from scipy.ndimage.filters import median_filter\n",
+    "from astropy.modeling import models, fitting\n",
+    "from astropy.nddata.utils import block_reduce"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %matplotlib notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(seed=4)  # For repeatability"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an image with a somewhat pathological background pattern.\n",
+    "\n",
+    "This image has a pixel-to-pixel RMS of 0.1, and the background non-uniformities we add are of comparable level to the pixel-to-pixel noise. So you can't get rid of the non-uniformities without doing a fair amount of smoothing. We'll add:\n",
+    " * A background gradient\n",
+    " * A few sinc-function blemishes scattered around the image. Make the period of the sinc function large enough that these blemishes shouldn't look much like sources (assumed to be only a few pixels to tens of pixels across).\n",
+    " \n",
+    "This particular test case was deviously chosen to be one where just adding higher orders to (say) a Chebyshev polynomial surface fit is likely to do a poor job. Similarly, increasing the order of a bicubic spline is not likely to be satisfactory."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set up grid and the random number seed for the simulation\n",
+    "\n",
+    "The test is best illustrated with a 2000x2000 image, but `shrink_factor` can be used to make the notebook run fast for testing. The random number seed is set to allow for repeatability. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "default_size = 2000\n",
+    "shrink_factor = 2  # To make the images smaller for faster execution\n",
+    "nrow = ncol = default_size // shrink_factor  # Image size\n",
+    "row, col = np.mgrid[0:nrow, 0:ncol]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the nasty sky background\n",
+    "\n",
+    "First the blemishes, then the gradient."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nblemish = 16//shrink_factor  # Number of sinc-function blemishes to add\n",
+    "row_centers = ncol*np.random.random_sample(size=nblemish)\n",
+    "col_centers = nrow*np.random.random_sample(size=nblemish)\n",
+    "# Make the wavelength of sinc ripples pretty large\n",
+    "width = 30+100.*np.random.random_sample(size=nblemish)\n",
+    "amplitude = 1.*np.random.random_sample(size=nblemish)\n",
+    "noiseless_sky = np.zeros((nrow, ncol), dtype=np.float32)\n",
+    "for rr, cc, w, a in zip(row_centers, col_centers, width, amplitude):\n",
+    "    r = np.sqrt((row-rr)**2 + (col-cc)**2)\n",
+    "    noiseless_sky = noiseless_sky + a*np.sinc(r/(w*np.pi))\n",
+    "blemishes = Table([col_centers, row_centers, width, amplitude],\n",
+    "                  names=['x', 'y', 'width', 'amplitude'])\n",
+    "blemishes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gradient = (1.*row)/nrow+(0.25*col)/ncol\n",
+    "noiseless_sky += gradient\n",
+    "noise = np.random.normal(scale=0.1, size=np.shape(noiseless_sky))\n",
+    "sky_bkgd = noiseless_sky + noise\n",
+    "mean_bkgd = sky_bkgd.mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.imshow(noiseless_sky)\n",
+    "plt.title('The noiseless sky background')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Look at it with noise added and then smoothed a bit\n",
+    "Smooth with a 10x10 boxcar kernel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sky_smoothed = convolve(sky_bkgd-mean_bkgd, Box2DKernel(10))\n",
+    "zmin, zmax = np.percentile(sky_smoothed, (0.1, 99.9))\n",
+    "plt.figure(figsize=(10, 5))\n",
+    "ax1 = plt.subplot(121)\n",
+    "ax1.imshow(sky_bkgd-mean_bkgd, vmin=zmin, vmax=zmax)\n",
+    "ax1.set_title('The sky with noise')\n",
+    "ax2 = plt.subplot(122, sharex=ax1, sharey=ax1)\n",
+    "ax2.set_title('The sky smoothed')\n",
+    "ax2.imshow(sky_smoothed, vmin=zmin, vmax=zmax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add some random sources\n",
+    "\n",
+    "We'll make the sources have elliptical Gaussian profiles with a variety of fluxes, sizes, and position angles. The sizes are kept relatively small relative to the structure in the background."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nsources = 5000//(shrink_factor**2)\n",
+    "sources = Table()\n",
+    "rand_sample = np.random.random_sample  # Save typing\n",
+    "random_sample = rand_sample(nsources)\n",
+    "sources['x_mean'] = 2.+(ncol-4.)*rand_sample(nsources)  # avoid the edges\n",
+    "sources['y_mean'] = 2.+(nrow-4.)*rand_sample(nsources)\n",
+    "sources['flux'] = 50*rand_sample(nsources)\n",
+    "sources['x_stddev'] = 5.*rand_sample(nsources)\n",
+    "sources['y_stddev'] = 5.*rand_sample(nsources)\n",
+    "sources['re'] = np.sqrt(sources['x_stddev']*sources['y_stddev'])\n",
+    "sources['theta'] = 180.*rand_sample(nsources)*np.pi / 180.\n",
+    "source_img = datasets.make_gaussian_sources_image(sky_bkgd.shape, sources)\n",
+    "scene = source_img + sky_bkgd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.imshow(scene-mean_bkgd, vmin=zmin, vmax=zmax)\n",
+    "plt.title('The scene, with the sources and nasty sky background')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Routine for making a plot to compare two images side by side"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_two(img1, img2, vmin, vmax, figsize=(10, 6), titles=['', ''],\n",
+    "             cmap=plt.cm.viridis):\n",
+    "    ax1 = plt.figure(figsize=figsize)\n",
+    "    ax1 = plt.subplot(121)\n",
+    "    ax1.imshow(img1, vmin=vmin, vmax=vmax, cmap=cmap)\n",
+    "    ax1.set_title(titles[0])\n",
+    "    ax2 = plt.subplot(122, sharex=ax1, sharey=ax1)\n",
+    "    ax2.imshow(img2, vmin=vmin, vmax=vmax, cmap=cmap)\n",
+    "    ax2.set_title(titles[1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Try using Photutils Background2D mesh grid as a  first attempt\n",
+    "\n",
+    "Now we need to make a first-cut estimate of the background. Photutils provides a flexible interface to estimating the background in a mesh of cells. We use the `Background2D` routine here, with a fairly typical set of parameters. See the [documentation](https://photutils.readthedocs.io/en/stable/api/photutils.background.Background2D.html#photutils.background.Background2D) \n",
+    "for more information. \n",
+    "\n",
+    "This tasks creates a mesh of rectangular cells covering the image. The unmasked pixels within each cell are \"averaged\" using a configurable robust statistic. These averages can then be \"averaged\" on some larger scale using a configurable robust statistic. This filtered set of averages is then used to feed an interpolation routine to make a smooth background. The default interpolation is a bicubic spline, but we will illustrate inverse-distance weighting interpolation later on in the notebook.\n",
+    "\n",
+    "Try adjusting the arguments to Background2D to see the effect. \n",
+    " * The second argument (50 below) is the mesh grid size. This can also be a rectangle -- e.g. (50,40) --  if desired.\n",
+    " * `sigma_clip` is the method to use for robust averaging within the grid cells.\n",
+    " * `filter_size` is how many cells to \"averaged\" before doing the interpolation. This can also be a rectangle -- e.g. (3,4) -- if desired.  \n",
+    " * `bkg_estimator` is the method to use for averaging the values in the cells.\n",
+    " * `exclude_percentile`  If a mesh has more than this percent of its pixels masked then it will be excluded from the low-resolution map. \n",
+    " * `interpolator` is the method to use to interpolate the background (bicubic spline in this case)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bkg = Background2D(scene, 50,\n",
+    "                   sigma_clip=astrostats.SigmaClip(sigma=3.),\n",
+    "                   filter_size=3,\n",
+    "                   exclude_percentile=50,\n",
+    "                   bkg_estimator=MedianBackground(),\n",
+    "                   interpolator=BkgZoomInterpolator(order=3))\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.imshow(bkg.background-noiseless_sky, vmin=0.1*zmin, vmax=0.1*zmax) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make a couple masks. The `make_source_mask` routine has a few options. Try changing them to see what they do. The aim here is to find and mask sources without seeing an appreciable enhancement of sources in regions where the background  is high. There are several parameters that can be adjusted:\n",
+    " * `nsigma` -- we will try this with 2 and 3 sigma cuts\n",
+    " * `npixels` -- the number of connected pixels above the threshold required before masking\n",
+    " * `dilate_size` -- the size of a square box-car filter used to grow the mask\n",
+    " * `filter_fwhm` -- the image is convolved with a Gaussian of this FWHM before thresholding. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask_2sigma = make_source_mask(scene-bkg.background, nsigma=2, npixels=3,\n",
+    "                               dilate_size=5, filter_fwhm=3)\n",
+    "mask_3sigma = make_source_mask(scene-bkg.background, nsigma=3, npixels=3,\n",
+    "                               dilate_size=5, filter_fwhm=3)\n",
+    "plot_two(mask_2sigma, mask_3sigma, 0, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Filter the image to estimate the background.   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sigma_clip = astrostats.SigmaClip(sigma=3.)\n",
+    "bkg_estimator = MedianBackground()\n",
+    "bkg1 = Background2D(scene, (30, 30), filter_size=(3, 3), mask=mask_3sigma,\n",
+    "                    sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)\n",
+    "bkg2 = Background2D(scene, (15, 15), filter_size=(3, 3), mask=mask_3sigma,\n",
+    "                    sigma_clip=sigma_clip, bkg_estimator=bkg_estimator)\n",
+    "plot_two(bkg1.background-noiseless_sky, bkg2.background-noiseless_sky,\n",
+    "         0.1*zmin, 0.1*zmax, titles=['bkg1', 'bkg2'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ring median filtering the image\n",
+    "\n",
+    "It's clear we are going to do more iteration to do the source removal. Before doing that, let's try another approach to removing the sources: the ring-median filter. To do this, create a filter kernel that is larger than the sources of interest. Use the scipy median-filtering routine to slide this across the image, taking the median of all the pixels within the ring. This basically gives a local-background estimate for each pixel. \n",
+    "\n",
+    "The cell below sets up the kernel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ring = Ring2DKernel(15, 5)\n",
+    "plt.imshow(ring.array)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare the scene (minus the mean background) to the filtered scene."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered = median_filter(scene, footprint=ring.array)\n",
+    "plot_two(scene-mean_bkgd, filtered-mean_bkgd, zmin, zmax,\n",
+    "         titles=['Sources', 'ring-median filtered'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Subtract the ring-median filtered image from the scene as the first cut at background subtraction. Convolve this with a kernel to smooth for source detection, and threshold that to identify pixels that are part of sources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "difference = scene-filtered\n",
+    "smoothed = convolve(difference, Gaussian2DKernel(3))\n",
+    "mask = smoothed > 1.*smoothed.std()\n",
+    "plot_two(difference, mask, zmin, zmax,\n",
+    "         titles=['scene minus ring-median filtered scene', 'mask'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It's often useful to grow the mask. This can be accomplished by convolving with a filter. Here, we adopt a circular tophat filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def dilate_mask(mask, tophat_size):\n",
+    "    ''' Take a mask and make the masked regions bigger.'''\n",
+    "    area = np.pi*tophat_size**2.\n",
+    "    kernel = Tophat2DKernel(tophat_size)\n",
+    "    dilated_mask = convolve(mask, kernel) >= 1./area\n",
+    "    return dilated_mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dilated_mask = dilate_mask(mask, 2)\n",
+    "plot_two(mask, dilated_mask, 0, 1, titles=['mask', 'dilated mask'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mask the image and see how many sources are still remaining"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_two(scene-noiseless_sky, (scene-noiseless_sky)*(1.-mask), zmin, zmax,\n",
+    "         titles=['scene without background', 'masked scene without background'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's make a fancier plot that shows background residuals, the residuals with the sources and source mask overlayed, and the background-subtracted scene. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_bkgd(scene, mask, bkgd, noiseless_bkgd, sources,\n",
+    "              zmin, zmax, factor=0.1,  # Control the colormap stretch\n",
+    "              figsize=(20, 10)):\n",
+    "    '''Make a three-panel plot of:\n",
+    "         * the residual sky background\n",
+    "         * the residual sky background times the mask with\n",
+    "           masked sources overlayed as '+' signs and\n",
+    "           unmasked sources overlayed as circles, and\n",
+    "         * The background-subtracted scene.\n",
+    "    '''\n",
+    "    residual = bkgd-noiseless_bkgd\n",
+    "    plt.figure(figsize=figsize)\n",
+    "    # Plot the background residual\n",
+    "    ax1 = plt.subplot(131)\n",
+    "    ax1.imshow(residual, vmin=factor*zmin, vmax=factor*zmax, origin='lower')\n",
+    "    ax1.set_title('residual sky background')\n",
+    "    ax2 = plt.subplot(132, sharex=ax1, sharey=ax1)\n",
+    "    ax2.imshow(residual*(1-mask), vmin=factor*zmin, vmax=factor*zmax,\n",
+    "               origin='lower')\n",
+    "    xs = np.rint(sources['x_mean']).astype(np.int32)\n",
+    "    ys = np.rint(sources['y_mean']).astype(np.int32)\n",
+    "    masked = mask[ys, xs]\n",
+    "    unmasked = np.invert(masked)\n",
+    "    ax2.scatter(xs[masked], ys[masked], s=sources['flux'][masked], marker='+',\n",
+    "                c='red', alpha=0.2)\n",
+    "    ax2.scatter(xs[unmasked], ys[unmasked], s=sources['flux'][unmasked],\n",
+    "                c='black', alpha=0.5)\n",
+    "    ax2.set_xlim(0, scene.shape[1])\n",
+    "    ax2.set_ylim(0, scene.shape[0])\n",
+    "    ax2.set_title('with masked + unmasked O sources')\n",
+    "    ax3 = plt.subplot(133, sharex=ax1, sharey=ax1)\n",
+    "    ax3.imshow(scene-bkgd, vmin=zmin, vmax=zmax, origin='lower')\n",
+    "    ax3.set_title('Scene minus estimated background')\n",
+    "    print(f\"Residual RMS, peak = {residual.std():.4f}, {residual.max():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_bkgd(scene, mask, filtered, noiseless_sky, sources, zmin, zmax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up some routines for convenience in iterating the mask\n",
+    "\n",
+    "Next we will try iterating in fitting the background and progressively removing sources at lower and lower S/N. We'll want to inspect at each step. Here are some functions to reduce typing:\n",
+    "\n",
+    "  * `SourceMask` -- This is an class to set up some parameters for the masking and give us a couple methods:\n",
+    "     * `single` -- appy an existing mask and then use photutils make_source_mask to make a new one; convolve the mask with a circular tophat kernel and threshold to dilate it\n",
+    "     * `multiple` -- repeatedly apply the `single` method to make a new mask. OR that with the previous masks.\n",
+    "  * `find_worst_residual_near_center` -- when plotting a zoomed in image for inspection, we'd like to select the section away from the edges that has the worst residuals\n",
+    "  * `plot_mask` -- plots the mask for the whole image and plots it as contours overlayed on a small subsection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def my_background(img, box_size, mask, interp=None, filter_size=1,\n",
+    "                  exclude_percentile=90):\n",
+    "    ''' Run photutils background with SigmaClip and MedianBackground'''\n",
+    "    if interp is None:\n",
+    "        interp = BkgZoomInterpolator()\n",
+    "    return Background2D(img, box_size,\n",
+    "                        sigma_clip=astrostats.SigmaClip(sigma=3.),\n",
+    "                        filter_size=filter_size,\n",
+    "                        bkg_estimator=MedianBackground(),\n",
+    "                        exclude_percentile=exclude_percentile,\n",
+    "                        mask=mask,\n",
+    "                        interpolator=interp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class SourceMask:\n",
+    "    def __init__(self, img, nsigma=3., npixels=3):\n",
+    "        ''' Helper for making & dilating a source mask.\n",
+    "             See Photutils docs for make_source_mask.'''\n",
+    "        self.img = img\n",
+    "        self.nsigma = nsigma\n",
+    "        self.npixels = npixels\n",
+    "\n",
+    "    def single(self, filter_fwhm=3., tophat_size=5., mask=None):\n",
+    "        '''Mask on a single scale'''\n",
+    "        if mask is None:\n",
+    "            image = self.img\n",
+    "        else:\n",
+    "            image = self.img*(1-mask)\n",
+    "        mask = make_source_mask(image, nsigma=self.nsigma,\n",
+    "                                npixels=self.npixels,\n",
+    "                                dilate_size=1, filter_fwhm=filter_fwhm)\n",
+    "        return dilate_mask(mask, tophat_size)\n",
+    "\n",
+    "    def multiple(self, filter_fwhm=[3.], tophat_size=[3.], mask=None):\n",
+    "        '''Mask repeatedly on different scales'''\n",
+    "        if mask is None:\n",
+    "            self.mask = np.zeros(self.img.shape, dtype=np.bool)\n",
+    "        for fwhm, tophat in zip(filter_fwhm, tophat_size):\n",
+    "            smask = self.single(filter_fwhm=fwhm, tophat_size=tophat)\n",
+    "            self.mask = self.mask | smask  # Or the masks at each iteration\n",
+    "        return self.mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_worst_residual_near_center(resid):\n",
+    "    '''Find the pixel location of the worst residual, avoiding the edges'''\n",
+    "    yc, xc = resid.shape[0]/2., resid.shape[1]/2.\n",
+    "    radius = resid.shape[0]/3.\n",
+    "    y, x = np.mgrid[0:resid.shape[0], 0:resid.shape[1]]\n",
+    "    mask = np.sqrt((y-yc)**2+(x-xc)**2) < radius\n",
+    "    rmasked = resid*mask\n",
+    "    return np.unravel_index(np.argmax(rmasked), resid.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_mask(scene, bkgd, mask, zmin, zmax, worst=None, smooth=0):\n",
+    "    '''Make a three-panel plot of:\n",
+    "         * the mask for the whole image,\n",
+    "         * the scene times the mask\n",
+    "         * a zoomed-in region, with the mask shown as contours\n",
+    "    '''\n",
+    "    if worst is None:\n",
+    "        y, x = find_worst_residual_near_center(bkgd-noiseless_sky)\n",
+    "    else:\n",
+    "        x, y = worst\n",
+    "    plt.figure(figsize=(20, 10))\n",
+    "    plt.subplot(131)\n",
+    "    plt.imshow(mask, vmin=0, vmax=1, cmap=plt.cm.gray, origin='lower')\n",
+    "    plt.subplot(132)\n",
+    "    if smooth == 0:\n",
+    "        plt.imshow((scene-bkgd)*(1-mask), vmin=zmin, vmax=zmax, origin='lower')\n",
+    "    else:\n",
+    "        smoothed = convolve((scene-bkgd)*(1-mask), Gaussian2DKernel(smooth))\n",
+    "        plt.imshow(smoothed*(1-mask), vmin=zmin/smooth, vmax=zmax/smooth,\n",
+    "                   origin='lower')\n",
+    "    plt.subplot(133)\n",
+    "    plt.imshow(scene-bkgd, vmin=zmin, vmax=zmax)\n",
+    "    plt.contour(mask, colors='red', alpha=0.2)\n",
+    "    plt.ylim(y-100, y+100)\n",
+    "    plt.xlim(x-100, x+100)\n",
+    "    return x, y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Estimate the background on a finer scale after masking sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bkg3 = my_background(scene, box_size=10, filter_size=5, mask=mask)\n",
+    "plot_bkgd(scene, mask, bkg1.background, noiseless_sky, sources, zmin, zmax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Try a different interpolation algorithm.\n",
+    "The Shephard inverse-distance weighting searches for \n",
+    "the N grid points nearest to the pixel of interest and weights them as $1/(D^p + \\lambda)$ \n",
+    "where $D$ is the distance to the neighbor, $p$ is a power, and $\\lambda$ is a parameter to \n",
+    "make the weighting of the neighbors smoother closer to the pixel of interest. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interpolator = BkgIDWInterpolator(n_neighbors=20, power=1, reg=30)\n",
+    "bkg4 = my_background(scene, box_size=10, filter_size=5, mask=mask,\n",
+    "                     interp=interpolator, exclude_percentile=90)\n",
+    "plot_bkgd(scene, mask, bkg4.background, noiseless_sky, sources, zmin, zmax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Make a deeper source mask. \n",
+    "This runs three iterations, with different kernel widths and different tophat sizes for growing the mask. Try varying `sigma`, `filter_fwhm` and `tophat_size` to see how they affect the sources. The aim is to mask sources that are easily visible, but leave plenty of pixels for tracing the background."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm = SourceMask(scene-bkg4.background, nsigma=1.5)\n",
+    "mask = sm.multiple(filter_fwhm=[1, 3, 5],\n",
+    "                   tophat_size=[4, 2, 1])\n",
+    "plot_mask(scene, bkg4.background, mask, zmin, zmax)\n",
+    "mask.sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Redo the background estimation using this new mask. \n",
+    "Play with `n_neighbors`, `box_size`, `filter_size` and `exclude_percentile` to see how they affect the residuals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interpolator = BkgIDWInterpolator(n_neighbors=20, power=0, reg=30)\n",
+    "bkg5 = my_background(scene, box_size=6, filter_size=3, mask=mask,\n",
+    "                     interp=interpolator, exclude_percentile=90)\n",
+    "plot_bkgd(scene, mask, bkg5.background, noiseless_sky, sources, zmin, zmax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check for bias in due to the galaxies\n",
+    "\n",
+    "Plot the value of the residual background under the central 3x3 pixels under each galaxy vs the flux of the galaxy, separately for those that are masked and those that are unmasked. First we need to get these values. Take the mean for  3x3 pixels centered on each source. Keep track of the ones that were masked in fitting the background and the ones that weren't so we can check separately for any bias."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bkgd = bkg5.background\n",
+    "sources['resid'] = 0.*sources['flux']\n",
+    "sources['bkgd'] = 0.*sources['flux']\n",
+    "sources['masked'] = np.zeros(len(sources), dtype=np.bool)\n",
+    "\n",
+    "residual_image = bkgd-noiseless_sky\n",
+    "for i in range(len(sources)):\n",
+    "    s = sources[i]\n",
+    "    x = np.rint(s['x_mean']).astype(np.int32)\n",
+    "    y = np.rint(s['y_mean']).astype(np.int32)\n",
+    "    xmin, xmax = max(0, x-1), min(ncol, x+1)\n",
+    "    ymin, ymax = max(0, y-1), min(nrow, y+1)\n",
+    "    sources['resid'][i] = residual_image[ymin:ymax, xmin:xmax].mean()\n",
+    "    sources['bkgd'][i] = bkgd[ymin:ymax, xmin:xmax].mean()\n",
+    "    sources['masked'][i] = mask[y, x]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "residual_image.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make a list of random positions and do the same measurement, as a control. Do this for a few more positions, tossing out the ones that are masked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_random = 5*len(sources)\n",
+    "resid_under_random = np.zeros(N_random, dtype=np.float64)\n",
+    "bkgd_under_random = np.zeros(N_random, dtype=np.float64)\n",
+    "masked_random = np.zeros(N_random, dtype=np.bool)\n",
+    "random_flux = sources['flux'][np.random.randint(0, len(sources), N_random)]\n",
+    "random_re = sources['re'][np.random.randint(0, len(sources), N_random)]\n",
+    "rnd_x = np.random.randint(2, ncol-2, size=N_random)\n",
+    "rnd_y = np.random.randint(2, nrow-2, size=N_random)\n",
+    "for i, x, y in zip(range(len(rnd_x)), rnd_x, rnd_y):\n",
+    "    resid_under_random[i] = residual_image[y-1:y+1, x-1:x+1].mean()\n",
+    "    bkgd_under_random[i] = bkgd[y-1:y+1, x-1:x+1].mean()\n",
+    "    masked_random[i] = mask[y-1:y+1, x-1:x+1].min().astype(np.bool)\n",
+    "resid_under_random = resid_under_random[~masked_random]\n",
+    "random_flux = random_flux[~masked_random]\n",
+    "random_re = random_re[~masked_random]\n",
+    "print(f\"Nsources, Nrandom: {len(sources)} {len(resid_under_random)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make lists of the masked and unmasked sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux = sources['flux']\n",
+    "resid = sources['resid']\n",
+    "re = sources['re']\n",
+    "masked = sources['masked']\n",
+    "unmasked = np.invert(sources['masked'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define a function `fit_line` to fit a line to the data points, and another function `fit_and_plot` to plot the data points and the best-fit line together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fit_line(x, y):\n",
+    "    line = models.Linear1D(1., 1.)\n",
+    "    fit = fitting.LinearLSQFitter()\n",
+    "    best_fit = fit(line, x, y)\n",
+    "    return best_fit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fit_and_plot(x, y, alpha=0.2, color='red', s=10,\n",
+    "                 marker='o', label=''):\n",
+    "    xfit = np.linspace(0, x.max(), 10)\n",
+    "    line = fit_line(x, y)\n",
+    "    plt.scatter(x, y, alpha=alpha, color=color, s=s, marker=marker,\n",
+    "                label=label)\n",
+    "    plt.plot(xfit, line(xfit), color=color, alpha=0.7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the residuals vs. source flux, separately for the masked, unmasked, and randomized source positions. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 5))\n",
+    "fit_and_plot(flux[unmasked], resid[unmasked], s=10.*re[unmasked],\n",
+    "             label='unmasked', color='black', alpha=0.5, marker='s')\n",
+    "fit_and_plot(flux[masked], resid[masked], s=10.*re[masked],\n",
+    "             label='masked', color='red', alpha=0.3, marker='o')\n",
+    "fit_and_plot(random_flux, resid_under_random, color='blue', alpha=0.1,\n",
+    "             marker='+', label='random')\n",
+    "plt.legend()\n",
+    "plt.ylim(-0.05, 0.05)\n",
+    "t = plt.title('residuals vs. flux')"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Plot the residuals vs. source radius, separately for the masked, unmasked, and randomized source positions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 6))\n",
+    "fit_and_plot(re[unmasked], resid[unmasked], s=2*flux[unmasked],\n",
+    "             label='unmasked', color='black', alpha=0.5, marker='s')\n",
+    "fit_and_plot(re[masked], resid[masked], s=flux[masked],\n",
+    "             label='masked', color='red', alpha=0.2, marker='o')\n",
+    "fit_and_plot(random_re, resid_under_random, color='blue', alpha=0.1,\n",
+    "             marker='+', label='random')\n",
+    "plt.legend()\n",
+    "plt.ylim(-0.05, 0.05)\n",
+    "t = plt.title('residuals vs. radius')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Testing for bias on real data\n",
+    "With real data, we can't take the residual relative to noiseless sky. However, we can check for evidence that the background under the masked areas is statistically higher than the background in the random areas. Given that astronomical sources have wings and these can't be subtracted without modeling them, it is very hard to achieve perfection here. This test will tell you the magnitude of the potential bias (in flux per pixel) and whether or not it looks significant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_masked = bkgd[mask].mean()\n",
+    "std_masked = bkgd[mask].std()\n",
+    "stderr_masked = mean_masked/(np.sqrt(len(bkgd[mask]))*std_masked)\n",
+    "\n",
+    "mean_unmasked = bkgd[~mask].mean()\n",
+    "std_unmasked = bkgd[~mask].std()\n",
+    "stderr_unmasked = mean_unmasked/(np.sqrt(len(bkgd[~mask]))*std_unmasked)\n",
+    "\n",
+    "diff = mean_masked - mean_unmasked\n",
+    "significance = diff/np.sqrt(stderr_masked**2 + stderr_unmasked**2)\n",
+    "\n",
+    "print(f\"Mean under masked pixels   = {mean_masked:.4f} +- {stderr_masked:.4f}\")\n",
+    "print(f\"Mean under unmasked pixels = \"\n",
+    "      f\"{mean_unmasked:.4f} +- {stderr_unmasked:.4f}\")\n",
+    "print(f\"Difference = {diff:.4f} at {significance:.2f} sigma significance\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Routines to facilitate looking at the RMS of the residual background as a function of scale\n",
+    "One way to evaluate whether the sky-subtraction looks sensible is to see whether the RMS is dropping sensibly as a\n",
+    "function of scale. It should drop linearly with the area size of the image sampled. \n",
+    "\n",
+    "To do this test, we would like to look at unmasked regions, but have them all have the same S/N. So we need a way to set up a mesh grid that has no masked pixels in each of the mesh areas.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def smoothsample_masked(img, mask, width=9):\n",
+    "    '''Take the means in squares that have no masked pixels'''\n",
+    "    nrow, ncol = img.shape\n",
+    "    w = width/2\n",
+    "    # Mask out the borders\n",
+    "    row, col = np.mgrid[0:nrow, 0:ncol]\n",
+    "    mask = mask | (row < w) | (row > nrow-w) | (col < w) | (col > ncol-w)\n",
+    "    # Make a list of the squares that contain no masked pixels\n",
+    "    mm = block_reduce(mask, width)\n",
+    "    means = block_reduce(img, width, func=np.mean)\n",
+    "    good = np.where(mm == 0)\n",
+    "    return means[good]\n",
+    "\n",
+    "\n",
+    "def calculate_stats(residual, mask, widths):\n",
+    "    stats = []\n",
+    "    for w in widths:\n",
+    "        val = smoothsample_masked(residual, mask, w)\n",
+    "        stats += [val.std()]\n",
+    "    return np.array(stats)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate the statistics for the different background estimates. These are the residuals of the masked \"scene\" -- i.e. with the sources in it, but masked as well as one might do for a real scene. These are to be compared to the \"perfect\" case of the noisy sky background minus the noiseless sky background, where the statistics are computed in the same unmasked cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rms = Table()\n",
+    "widths = rms['widths'] = np.arange(3, 30, 1)\n",
+    "rms['bkg1'] = calculate_stats(scene-bkg1.background, mask, widths)\n",
+    "rms['bkg2'] = calculate_stats(scene-bkg2.background, mask, widths)\n",
+    "rms['bkg3'] = calculate_stats(scene-bkg3.background, mask, widths)\n",
+    "rms['bkg4'] = calculate_stats(scene-bkg4.background, mask, widths)\n",
+    "rms['bkg5'] = calculate_stats(scene-bkg5.background, mask, widths)\n",
+    "rms['perfect'] = calculate_stats(sky_bkgd-noiseless_sky, mask, widths)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the results relative to the perfect case (we've commented out the initial `bkg1` estimate just to make the scale more visible for the better estimates). It is worth noting that the `bkg1` is typical of what one might get from SExtractor, which offers only a single pass for the background estimation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 6))\n",
+    "perfect = rms['perfect']\n",
+    "# plt.plot(rms['widths'],rms['bkg1']/perfect,alpha=0.5,label='bkg1')\n",
+    "plt.plot(rms['widths'], rms['bkg2']/perfect, alpha=0.5, label='bkg2')\n",
+    "plt.plot(rms['widths'], rms['bkg3']/perfect, alpha=0.5, label='bkg3')\n",
+    "plt.plot(rms['widths'], rms['bkg4']/perfect, alpha=0.5, label='bkg4')\n",
+    "plt.plot(rms['widths'], rms['bkg5']/perfect, alpha=0.5, label='bkg5')\n",
+    "plt.plot(rms['widths'], rms['perfect']/perfect, 'k-', alpha=1, label='perfect')\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/jdat_notebooks/background_estimation_imaging/Imaging Sky Background Estimation.ipynb
+++ b/jdat_notebooks/background_estimation_imaging/Imaging Sky Background Estimation.ipynb
@@ -101,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create an image with a somewhat pathological background pattern.\n",
+    "## Create an image with a somewhat pathological background pattern\n",
     "\n",
     "This image has a pixel-to-pixel RMS of 0.1, and the background non-uniformities we add are of comparable level to the pixel-to-pixel noise. So you can't get rid of the non-uniformities without doing a fair amount of smoothing. We'll add:\n",
     " * A background gradient\n",

--- a/jdat_notebooks/background_estimation_imaging/requirements
+++ b/jdat_notebooks/background_estimation_imaging/requirements
@@ -1,0 +1,5 @@
+python==3.7
+numpy==1.17.2
+astropy==3.2.1
+matplotlib==3.1.1
+scipy==0.7


### PR DESCRIPTION
Draft notebook for a complicated sky estimation workflow, illustrating different options for filtering and interpolation, and suggesting a few metrics (plots) to assess success. These assessments were the main motivation for doing the notebook, since I've rarely seen people try to quantify how good is "good enough" for sky estimation. 

There are ample opportunities here for interactive visualization. It would be great to be able to zoom and pan and rescale the colormaps on the images, for example, with the different panels locked.

@larrybradley Would be a good reviewer. 