### PR TITLE
Update env to get notebook working

### DIFF
--- a/jdat_notebooks/environment.yml
+++ b/jdat_notebooks/environment.yml
@@ -7,7 +7,7 @@ channels:
   - defaults
 
 dependencies:
-  - numpy=1.15.4
+  - numpy
   - astropy
   - scipy
   - astroquery


### PR DESCRIPTION
This is an update to the environment file to try to get the current notebook to execute (from #73).

It looks like the underlying problem was that there was a numpy version incompatibility with photutils which has been fixed since the version was pinned (in the file from `spacetelescope/notebooks`).  So trying to un-pin to get it to run.