### PR TITLE
fix very minor pip nagging in CI

### DIFF
--- a/jdat_notebooks/environment.yml
+++ b/jdat_notebooks/environment.yml
@@ -7,6 +7,7 @@ channels:
   - defaults
 
 dependencies:
+  - pip
   - numpy
   - astropy
   - scipy


### PR DESCRIPTION
This is a very minor fix inspired by noticing the following message in the circle-ci logs:
```
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
```
so I think this has no effect other than removing that warning message, but still seems like a good idea.

I think it's best *not* to merge this until #86 is in though, as it might conflict and that one's a lot more complicated than this one.