### PR TITLE
Fixes to spectral extraction notebook

### DIFF
--- a/jdat_notebooks/optimal_extraction/Spectral Extraction.ipynb
+++ b/jdat_notebooks/optimal_extraction/Spectral Extraction.ipynb
@@ -67,7 +67,7 @@
     "from matplotlib.patches import Rectangle\n",
     "from ipywidgets import interact\n",
     "import ipywidgets as widgets\n",
-    "from webbpsf import NIRSpec, display_psf\n",
+    "\n",
     "plt.style.use(astropy_mpl_style) #use the style we imported for matplotlib displays"
    ]
   },
@@ -1355,6 +1355,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "`webbpsf` is only needed here so we import it at the start of this appendix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from webbpsf import NIRSpec, display_psf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Instead of using a PSF template, we can generate a PSF directly from the instrument model with [WebbPSF](https://webbpsf.readthedocs.io/en/stable/index.html). Currently, only the F110W and F140X imaging filters are supported, but we'll walk through the process anyway for whenever more filters become available.\n",
     "\n",
     "The primary function of WebbPSF is to produce imaging PSFs; however, it *can* generate a set of monochromatic PSFs, which we can combine."
@@ -1364,7 +1380,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "WebbPSF has a number of data files which are required to run, so we'll begin by verifying that they can be accessed (and downloading them if necessary)."
+    "WebbPSF has a number of data files which are required to run, so we'll begin by verifying that they can be accessed (and downloading them if necessary).\n",
+    "\n",
+    "Note that you will see a big red error message if you have not yet downloaded the data files. Don't worry, as long as you see \"Downloading WebbPSF data files.\" everything is still proceeding as expected."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Developer Note:*\n",
+    "WebbPSF should be updated so that the red error doesn't appear.  See https://github.com/spacetelescope/webbpsf/issues/380"
    ]
   },
   {

--- a/jdat_notebooks/optimal_extraction/Spectral Extraction.ipynb
+++ b/jdat_notebooks/optimal_extraction/Spectral Extraction.ipynb
@@ -68,8 +68,7 @@
     "from ipywidgets import interact\n",
     "import ipywidgets as widgets\n",
     "from webbpsf import NIRSpec, display_psf\n",
-    "plt.style.use(astropy_mpl_style) #use the style we imported for matplotlib displays\n",
-    "plt.ioff() # we unintuitively need to turn off interactive plots"
+    "plt.style.use(astropy_mpl_style) #use the style we imported for matplotlib displays"
    ]
   },
   {
@@ -175,8 +174,7 @@
     "fig1 = plt.figure() # we save these in dummy variables to avoid spurious Jupyter Notebook output\n",
     "img1 = plt.imshow(resampled_2d_image, cmap='gray', aspect=aspect_ratio, \n",
     "                  norm=norm, interpolation='none')\n",
-    "clb1 = plt.colorbar()\n",
-    "plt.show()"
+    "clb1 = plt.colorbar()"
    ]
   },
   {
@@ -267,7 +265,6 @@
     "                             facecolor='none', edgecolor='b', linestyle='--')\n",
     "current_axis = plt.gca()\n",
     "current_axis.add_patch(region_rectangle)\n",
-    "plt.show()\n",
     "\n",
     "# interactive widget controls\n",
     "def region(x1=0, y1=0, x2=region_w-1, y2=region_h-1):\n",
@@ -313,8 +310,7 @@
     "fig3 = plt.figure()\n",
     "img3 = plt.imshow(extraction_region, cmap='gray', aspect=aspect_ratio, \n",
     "                  norm=er_norm, interpolation='none')\n",
-    "clb3 = plt.colorbar()\n",
-    "plt.show()"
+    "clb3 = plt.colorbar()"
    ]
   },
   {
@@ -397,8 +393,6 @@
     "lin4, = pax4.plot(xd_pixels, slice_0, 'k-')\n",
     "pax4.set_xlabel('Cross-dispersion pixel')\n",
     "pax4.axes.set_ylabel('Coadded signal')\n",
-    "\n",
-    "plt.show()\n",
     "\n",
     "column_slider = widgets.IntSlider(initial_column, 0, er_nx-1, 1)\n",
     "width_slider = widgets.IntSlider(slice_width, 1, er_nx-1, 1)\n",
@@ -495,8 +489,7 @@
     "kern5 = plt.plot(xd_pixels, kernel_slice / kernel_slice[max_pixel], label='Kernel Slice')\n",
     "moff5 = plt.plot(xd_pixels, moffat_profile(xd_pixels), label='Moffat Profile')\n",
     "gaus5 = plt.plot(xd_pixels, gauss_profile(xd_pixels), label='Gaussian Profile')\n",
-    "plt.legend()\n",
-    "plt.show()"
+    "plt.legend()"
    ]
   },
   {
@@ -602,8 +595,7 @@
     "fax6.legend()\n",
     "lin6 = fln6.plot(xd_pixels, kernel_slice, label='Kernel Slice')\n",
     "fit6 = fln6.plot(xd_pixels, fit_line, 'o', label='Extraction Kernel')\n",
-    "fln6.legend()\n",
-    "plt.show()"
+    "fln6.legend()"
    ]
   },
   {
@@ -660,8 +652,7 @@
     "plt.subplots_adjust(hspace=0.05)\n",
     "fwhm_img = ax_fwhm[0].imshow(binned_spectrum)\n",
     "fwhm_plot = ax_fwhm[1].plot(bin_centers, bin_fwhms, 'x')\n",
-    "fit_plot = ax_fwhm[1].plot(bin_centers, fwhm_fit(bin_centers))\n",
-    "plt.show()"
+    "fit_plot = ax_fwhm[1].plot(bin_centers, fwhm_fit(bin_centers))"
    ]
   },
   {


### PR DESCRIPTION
This PR makes several tweaks to the spectral extrraction notebook.  More specifically:

1. Removes the use of `ioff` and `plt.show` - that does not play consistently with some browsers - this PR instead skips `ioff` *and* `show`, depending on the `interactive` mechanism to show the figures automatically.  It's possible this breaks something I'm missing, but it looked fine to me, and without this PR instead there are several "blank" figures. (There's a third solution to this but I won't suggest it unless it's needed)
2. Mentions the big red error that comes up if you need to do the webbpsf data download. The first external user who tried this thought something was broken when they saw that warning, so it needs attention.  (and adds a developer note that relates this to spacetelescope/webbpsf#380 )
3. Moved the webbpsf import down to the appendix.  This is good because I foresee many users not wanting to go all the way to the second appendix and they shouldn't need to have webbpsf installed if so.


cc @gkanarek @robelgeda 