### PR TITLE
add readme with main transition information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# dat_pyinthesky
+
+This repository is a sandbox and drafting space for assorted efforts for STScI's data analysis tools. (Particularly, but not exclusively, for the Data Analysis Tools Branch.)
+
+## If you locally cloned this repo before 5 Feb 2021
+
+The primary branch for this repo has been transitioned from ``master`` to ``main``.  If you have a local clone of this repository and want to keep your local branch in sync with this repo, you'll need to do the following:
+```
+% git branch -m master main
+% git fetch origin
+% git branch -u origin/main main
+```
+If you are using a GUI to manage your repos you'll have to find the equivalent commands as it's different for different programs. Alternatively, you can just delete your local clone and re-clone!

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repository is a sandbox and drafting space for assorted efforts for STScI's
 
 ## If you locally cloned this repo before 5 Feb 2021
 
-The primary branch for this repo has been transitioned from ``master`` to ``main``.  If you have a local clone of this repository and want to keep your local branch in sync with this repo, you'll need to do the following:
+The primary branch for this repo has been transitioned from ``master`` to ``main``.  If you have a local clone of this repository and want to keep your local branch in sync with this repo, you'll need to do the following in your local clone from your terminal:
 ```
-% git branch -m master main
-% git fetch origin
-% git branch -u origin/main main
+git branch -m master main
+git fetch origin
+git branch -u origin/main main
 ```
 If you are using a GUI to manage your repos you'll have to find the equivalent commands as it's different for different programs. Alternatively, you can just delete your local clone and re-clone!


### PR DESCRIPTION
This adds a readme with a bit of information about the repo and particularly a note for anyone who cloned before the switch to `main` (which I will do at the same time as merging this).

I'll push a similar change to `jdat_notebooks`, but we can review it here.