### PR TITLE
archiving documentation updates

### DIFF
--- a/jdat_notebooks/README.md
+++ b/jdat_notebooks/README.md
@@ -1,8 +1,14 @@
 # James Webb Space Telescope Data Analysis Tool Notebooks (pyinthesky)
 
+🟥 As of 06/15/2022: Please note that ``dat_pyinthesky`` is in the process of being archived. We refer all users to [``jdat_notebooks``](https://github.com/spacetelescope/jdat_notebooks), where support and functionality for contributing authors is now being supported by the implementation of development branches for newer notebooks, while finalized notebooks are maintained in Main. 🟥
+
+---------------
+
+### Old Instruction Before 06/15/2022
+
 ``jdat_notebooks`` are one component of STScI's larger [Data Analysis Tools Ecosystem](https://jwst-docs.stsci.edu/jwst-post-pipeline-data-analysis).
 
-``dat_pyinthesky`` is intended for the developer community wishing to contribute notebooks or technical expertise.  If you are part of the broader community wishing to use the finalized notebooks, we refer you to [jdat_notebooks](https://github.com/spacetelescope/jdat_notebooks).  If you wish to contribute notebooks, please follow [contributing instructions](https://github.com/spacetelescope/jdat_notebooks/blob/master/CONTRIBUTING.md).
+``dat_pyinthesky`` is intended for the developer community wishing to contribute notebooks or technical expertise.  If you are part of the broader community wishing to use the finalized notebooks, we refer you to [``jdat_notebooks``](https://github.com/spacetelescope/jdat_notebooks).  If you wish to contribute notebooks, please follow [contributing instructions](https://github.com/spacetelescope/jdat_notebooks/blob/master/CONTRIBUTING.md).
 
 This repository contains Jupyter notebooks intended for the developer community wishing to contribute notebooks or technical expertise.  The notebooks illustrate workflows for post-pipeline analysis of JWST data. The notebooks are likely to be useful for analyzing data from other observatories as well.
 

--- a/jdat_notebooks/README.md
+++ b/jdat_notebooks/README.md
@@ -1,10 +1,10 @@
 # James Webb Space Telescope Data Analysis Tool Notebooks (pyinthesky)
 
-🟥 As of 06/15/2022: Please note that ``dat_pyinthesky`` is in the process of being archived. We refer all users to [``jdat_notebooks``](https://github.com/spacetelescope/jdat_notebooks), where support and functionality for contributing authors is now being supported by the implementation of development branches for newer notebooks, while finalized notebooks are maintained in Main. 🟥
+🟥 As of 06/15/2022: Please note that ``dat_pyinthesky`` is in the process of being archived. We refer all users to [``jdat_notebooks``](https://github.com/spacetelescope/jdat_notebooks), where documentation and instructions to contribute notebooks will be updated soon. 🟥
 
 ---------------
 
-### Old Instruction Before 06/15/2022
+### Old Instruction (Before 06/15/2022)
 
 ``jdat_notebooks`` are one component of STScI's larger [Data Analysis Tools Ecosystem](https://jwst-docs.stsci.edu/jwst-post-pipeline-data-analysis).
 


### PR DESCRIPTION
Starting to redirect users from dat_pyinthesky to jdat_notebooks. Not exactly ready to archive yet, but I don't want outside users to even think about using dat_pyinthesky anymore.